### PR TITLE
Remove colliding file from the working tree

### DIFF
--- a/man/IO_URING_CHECK_VERSION.3
+++ b/man/IO_URING_CHECK_VERSION.3
@@ -1,1 +1,0 @@
-io_uring_check_version.3


### PR DESCRIPTION
It makes it difficult to work with ClickHouse on Mac which has a case-insensitive filesystem 

```
❯ git clone --recursive git@github.com:ClickHouse/liburing.git
Cloning into 'liburing'...
remote: Enumerating objects: 13650, done.
remote: Counting objects: 100% (6336/6336), done.
remote: Compressing objects: 100% (1211/1211), done.
remote: Total 13650 (delta 5379), reused 5327 (delta 5121), pack-reused 7314 (from 1)
Receiving objects: 100% (13650/13650), 3.00 MiB | 5.38 MiB/s, done.
Resolving deltas: 100% (9697/9697), done.
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  'man/IO_URING_CHECK_VERSION.3'
  'man/io_uring_check_version.3'
```

Small demo: 

MacOS:
```
❯ ls
❯ touch file
❯ ls
file
❯ touch FILE
❯ ls
file
❯
```

Linux: 

```
ubuntu ~/demo$ ls
ubuntu ~/demo$ touch file
ubuntu ~/demo$ ls
file
ubuntu ~/demo$ touch FILE
ubuntu ~/demo$ ls
FILE  file
ubuntu ~/demo$
```